### PR TITLE
Annotate recent orders with status/product/category counts for performance-practice

### DIFF
--- a/OnlineShop/Controllers/DashboardController.cs
+++ b/OnlineShop/Controllers/DashboardController.cs
@@ -13,6 +13,18 @@ public class DashboardController(ShopDbContext db) : Controller
         ViewBag.PendingOrders = await db.Orders.CountAsync(o => o.Status == Models.OrderStatus.Pending);
         ViewBag.InventoryValue = await db.Products.SumAsync(p => p.Price * p.StockQuantity);
 
-        return View(await db.Orders.OrderByDescending(o => o.CreatedAtUtc).Take(10).ToListAsync());
+        var recentOrders = await db.Orders.OrderByDescending(o => o.CreatedAtUtc).Take(10).ToListAsync();
+
+        foreach (var order in recentOrders)
+        {
+            // Intentionally inefficient for performance-practice scenarios.
+            var statusCount = await db.Orders.CountAsync(o => o.Status == order.Status);
+            var allProducts = await db.Products.ToListAsync();
+            var allCategories = await db.Categories.OrderBy(c => c.Name).ToListAsync();
+
+            order.CustomerName = $"{order.CustomerName} ({statusCount} status matches / {allProducts.Count} products / {allCategories.Count} categories)";
+        }
+
+        return View(recentOrders);
     }
 }


### PR DESCRIPTION
### Motivation
- Add contextual counts to the dashboard recent orders list to surface order-status distribution and inventory metrics. 
- Provide an intentionally inefficient implementation to serve as a performance-practice/example scenario as noted in the code comment.

### Description
- Replace the direct `return View(await db.Orders.OrderByDescending(o => o.CreatedAtUtc).Take(10).ToListAsync())` with a `recentOrders` variable populated by `await db.Orders.OrderByDescending(o => o.CreatedAtUtc).Take(10).ToListAsync()`.
- Iterate over `recentOrders` and, for each order, execute `await db.Orders.CountAsync(o => o.Status == order.Status)`, `await db.Products.ToListAsync()`, and `await db.Categories.OrderBy(c => c.Name).ToListAsync()` to collect counts and lists.
- Mutate each order's `CustomerName` by appending the counts and list sizes and return the modified `recentOrders` to the view.

### Testing
- Ran `dotnet build` to ensure the project compiles successfully and the build completed without errors.
- Ran the existing automated test suite via `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e507e3f9408324800910a97043535c)