### PR TITLE
Add current app inventory and rewrite decision docs

### DIFF
--- a/docs/current-app-inventory.md
+++ b/docs/current-app-inventory.md
@@ -1,0 +1,126 @@
+# Current App Inventory
+
+This inventory describes the current ASP.NET Core MVC application structure and behavior.
+
+## C# model files
+
+- `OnlineShop/Models/Category.cs`
+- `OnlineShop/Models/Order.cs`
+- `OnlineShop/Models/Product.cs`
+
+## Model details
+
+### `OnlineShop/Models/Product.cs`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Id` | `int` | Primary identifier. |
+| `Name` | `string` | Product display name. Defaults to `string.Empty`. |
+| `Sku` | `string` | Stock keeping unit. Defaults to `string.Empty`. |
+| `Price` | `decimal` | Product price. |
+| `StockQuantity` | `int` | Current inventory count. |
+| `CategoryId` | `int` | Foreign key to the related category. |
+| `Category` | `Category?` | Optional navigation property for the related category. |
+
+### `OnlineShop/Models/Category.cs`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Id` | `int` | Primary identifier. |
+| `Name` | `string` | Category display name. Defaults to `string.Empty`. |
+| `Description` | `string` | Category description. Defaults to `string.Empty`. |
+| `Products` | `ICollection<Product>` | Navigation collection of products in the category. Defaults to an empty `List<Product>`. |
+
+### `OnlineShop/Models/Order.cs`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Id` | `int` | Primary identifier. |
+| `CustomerName` | `string` | Customer display name. Defaults to `string.Empty`. |
+| `TotalAmount` | `decimal` | Total order amount. |
+| `CreatedAtUtc` | `DateTime` | Order creation timestamp in UTC. |
+| `Status` | `OrderStatus` | Current order status. |
+
+#### `OrderStatus` enum values
+
+| Value | Numeric value |
+| --- | ---: |
+| `Pending` | `0` |
+| `Completed` | `1` |
+| `Cancelled` | `2` |
+
+## Controller files
+
+- `OnlineShop/Controllers/CategoriesController.cs`
+- `OnlineShop/Controllers/DashboardController.cs`
+- `OnlineShop/Controllers/OrdersController.cs`
+- `OnlineShop/Controllers/ProductsController.cs`
+
+## Controller routes
+
+The app uses the conventional MVC route pattern `{controller=Dashboard}/{action=Index}/{id?}`. The routes below are provided by the current controller actions.
+
+### `ProductsController`
+
+| HTTP method | Route | Action | Behavior |
+| --- | --- | --- | --- |
+| `GET` | `/Products` | `Index` | Lists products including their categories, ordered by product name. |
+| `GET` | `/Products/Index` | `Index` | Lists products including their categories, ordered by product name. |
+| `GET` | `/Products/Create` | `Create` | Shows the product creation form after loading category options. |
+| `POST` | `/Products/Create` | `Create` | Creates a product when model state is valid; otherwise redisplays the form with category options. |
+
+### `CategoriesController`
+
+| HTTP method | Route | Action | Behavior |
+| --- | --- | --- | --- |
+| `GET` | `/Categories` | `Index` | Lists categories ordered by name. |
+| `GET` | `/Categories/Index` | `Index` | Lists categories ordered by name. |
+| `GET` | `/Categories/Create` | `Create` | Shows the category creation form. |
+| `POST` | `/Categories/Create` | `Create` | Creates a category when model state is valid; otherwise redisplays the form. |
+
+### `OrdersController`
+
+| HTTP method | Route | Action | Behavior |
+| --- | --- | --- | --- |
+| `GET` | `/Orders` | `Index` | Lists orders ordered by creation time descending. |
+| `GET` | `/Orders/Index` | `Index` | Lists orders ordered by creation time descending. |
+| `GET` | `/Orders/Create` | `Create` | Shows the order creation form with `CreatedAtUtc` initialized to the current UTC time. |
+| `POST` | `/Orders/Create` | `Create` | Creates an order with `CreatedAtUtc` reset to the current UTC time when model state is valid; otherwise redisplays the form. |
+
+### `DashboardController`
+
+| HTTP method | Route | Action | Behavior |
+| --- | --- | --- | --- |
+| `GET` | `/` | `Index` | Default route; shows dashboard totals and recent orders. |
+| `GET` | `/Dashboard` | `Index` | Shows dashboard totals and recent orders. |
+| `GET` | `/Dashboard/Index` | `Index` | Shows dashboard totals and recent orders. |
+
+## Razor view files
+
+- `OnlineShop/Views/Categories/Create.cshtml`
+- `OnlineShop/Views/Categories/Index.cshtml`
+- `OnlineShop/Views/Dashboard/Index.cshtml`
+- `OnlineShop/Views/Orders/Create.cshtml`
+- `OnlineShop/Views/Orders/Index.cshtml`
+- `OnlineShop/Views/Products/Create.cshtml`
+- `OnlineShop/Views/Products/Index.cshtml`
+- `OnlineShop/Views/Shared/_Layout.cshtml`
+- `OnlineShop/Views/_ViewImports.cshtml`
+- `OnlineShop/Views/_ViewStart.cshtml`
+
+## Seed data in `Program.cs`
+
+When the database is created and no categories exist, the app seeds:
+
+- Categories:
+  - `Pantry` with description `Shelf-stable grocery items`.
+  - `Produce` with description `Fresh fruits and vegetables`.
+- Products:
+  - `Olive Oil` with SKU `PAN-001`, price `14.99`, stock quantity `34`, in `Pantry`.
+  - `Brown Rice` with SKU `PAN-002`, price `7.49`, stock quantity `50`, in `Pantry`.
+  - `Apples` with SKU `PRO-001`, price `3.25`, stock quantity `80`, in `Produce`.
+- One order:
+  - Customer name `Walk-in Customer`.
+  - `CreatedAtUtc` set to the current UTC time at seeding.
+  - Total amount `22.48`.
+  - Status `Completed`.

--- a/docs/rewrite-decisions.md
+++ b/docs/rewrite-decisions.md
@@ -1,0 +1,38 @@
+# Rewrite Decisions
+
+## Chosen TypeScript stack
+
+- Next.js with TypeScript for the full-stack web application.
+- Prisma as the data access layer and migration tool.
+- PostgreSQL as the relational database.
+- React components and Next.js routing for the user interface.
+
+## Why Next.js
+
+- It provides a single TypeScript framework for the UI and server-side application code.
+- File-based routing gives the rewrite a clear structure that maps well from the existing MVC controller and view organization.
+- Server-side rendering and server components can support dashboard and inventory pages that need database-backed data at request time.
+- API routes or server actions provide a straightforward replacement for current form-post controller actions.
+- The ecosystem is mature, widely documented, and well supported for deployment.
+
+## Why Prisma
+
+- Prisma gives strongly typed database access from TypeScript, reducing mismatch between application models and database schema.
+- Its schema file and generated client make the product, category, and order models explicit and easy to review.
+- Prisma migrations provide a repeatable way to evolve the database during and after the rewrite.
+- Relations such as `Product` to `Category` can be modeled directly and queried ergonomically.
+
+## Why PostgreSQL
+
+- PostgreSQL is a production-ready relational database with strong support for constraints, transactions, indexes, and relational queries.
+- It fits the existing relational shape of categories, products, and orders.
+- It works well with Prisma and common Next.js deployment platforms.
+- It provides a better long-term production target than the current local SQLite setup.
+
+## What will not be migrated from the old stack
+
+- ASP.NET Core MVC controllers, Razor views, and C# model classes will not be carried forward directly.
+- Entity Framework Core `DbContext`, EF-specific configuration, and SQLite setup will not be migrated.
+- The current `Program.cs` hosting and middleware setup will be replaced by Next.js application configuration.
+- The intentionally inefficient dashboard query pattern will not be preserved; the rewrite should use efficient aggregate and relation queries.
+- Server-rendered Razor layout and view conventions will be replaced by React and Next.js layout conventions.


### PR DESCRIPTION
### Motivation

- Capture the current ASP.NET Core MVC application's surface area to help scope a TypeScript rewrite. 
- Record model shapes, controller routes, views, and seed data for accurate migration planning. 
- Document the chosen TypeScript stack and what will not be migrated to guide the rewrite effort.

### Description

- Add `docs/current-app-inventory.md` which enumerates C# model files and documents `OnlineShop/Models/Product.cs`, `OnlineShop/Models/Category.cs`, and `OnlineShop/Models/Order.cs` fields and `OrderStatus` enum values. 
- Document controller files and every route provided by `ProductsController`, `CategoriesController`, `OrdersController`, and `DashboardController`, plus a list of all Razor view files. 
- Add `docs/rewrite-decisions.md` which records the chosen stack (`Next.js`, `Prisma`, `PostgreSQL`), reasons for each choice, and a short list of legacy pieces that will not be migrated.

### Testing

- No automated tests were run because this is a documentation-only change. 
- Basic repository validations and file-inspection commands were executed to verify the two docs (`docs/current-app-inventory.md` and `docs/rewrite-decisions.md`) were created and contain the expected content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ef6d186083248a94a607360aa043)