### PR TITLE
Extract database seeding into ShopDatabaseInitializer, inject TimeProvider, and add tests

### DIFF
--- a/OnlineShop.Tests/Data/ShopDatabaseInitializerTests.cs
+++ b/OnlineShop.Tests/Data/ShopDatabaseInitializerTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using OnlineShop.Data;
+using OnlineShop.Models;
+
+namespace OnlineShop.Tests.Data;
+
+public sealed class ShopDatabaseInitializerTests
+{
+    [Fact]
+    public void Initialize_creates_the_expected_shop_data()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var db = CreateContext(connection);
+        var createdAt = new DateTimeOffset(2025, 4, 3, 2, 1, 0, TimeSpan.Zero);
+
+        new ShopDatabaseInitializer(db, new FixedTimeProvider(createdAt)).Initialize();
+
+        Assert.Equal(new[] { "Pantry", "Produce" }, db.Categories.OrderBy(category => category.Name).Select(category => category.Name));
+        Assert.Equal(new[] { "Apples", "Brown Rice", "Olive Oil" }, db.Products.OrderBy(product => product.Name).Select(product => product.Name));
+        var order = Assert.Single(db.Orders);
+        Assert.Equal("Walk-in Customer", order.CustomerName);
+        Assert.Equal(22.48m, order.TotalAmount);
+        Assert.Equal(OrderStatus.Completed, order.Status);
+        Assert.Equal(createdAt.UtcDateTime, order.CreatedAtUtc);
+    }
+
+    [Fact]
+    public void Initialize_does_not_duplicate_data_when_the_shop_is_already_initialized()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var db = CreateContext(connection);
+        var initializer = new ShopDatabaseInitializer(db, new FixedTimeProvider(DateTimeOffset.UnixEpoch));
+
+        initializer.Initialize();
+        initializer.Initialize();
+
+        Assert.Equal(2, db.Categories.Count());
+        Assert.Equal(3, db.Products.Count());
+        Assert.Single(db.Orders);
+    }
+
+    private static ShopDbContext CreateContext(SqliteConnection connection)
+        => new(new DbContextOptionsBuilder<ShopDbContext>().UseSqlite(connection).Options);
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/OnlineShop.Tests/OnlineShop.Tests.csproj
+++ b/OnlineShop.Tests/OnlineShop.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../OnlineShop/OnlineShop.csproj" />
+  </ItemGroup>
+</Project>

--- a/OnlineShop.Tests/Usings.cs
+++ b/OnlineShop.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/OnlineShop.sln
+++ b/OnlineShop.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnlineShop", "OnlineShop\OnlineShop.csproj", "{2CE4FAFF-3C42-449D-BE9C-485E07F7B67A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnlineShop.Tests", "OnlineShop.Tests\OnlineShop.Tests.csproj", "{531018B4-C5D5-4C03-A0AB-EF992B7F5262}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{2CE4FAFF-3C42-449D-BE9C-485E07F7B67A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CE4FAFF-3C42-449D-BE9C-485E07F7B67A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CE4FAFF-3C42-449D-BE9C-485E07F7B67A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{531018B4-C5D5-4C03-A0AB-EF992B7F5262}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{531018B4-C5D5-4C03-A0AB-EF992B7F5262}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{531018B4-C5D5-4C03-A0AB-EF992B7F5262}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{531018B4-C5D5-4C03-A0AB-EF992B7F5262}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OnlineShop/Data/ShopDatabaseInitializer.cs
+++ b/OnlineShop/Data/ShopDatabaseInitializer.cs
@@ -1,0 +1,35 @@
+using OnlineShop.Models;
+
+namespace OnlineShop.Data;
+
+public sealed class ShopDatabaseInitializer(ShopDbContext db, TimeProvider timeProvider)
+{
+    public void Initialize()
+    {
+        db.Database.EnsureCreated();
+
+        if (db.Categories.Any())
+        {
+            return;
+        }
+
+        var pantry = new Category { Name = "Pantry", Description = "Shelf-stable grocery items" };
+        var produce = new Category { Name = "Produce", Description = "Fresh fruits and vegetables" };
+
+        db.Categories.AddRange(pantry, produce);
+        db.Products.AddRange(
+            new Product { Name = "Olive Oil", Sku = "PAN-001", Price = 14.99m, StockQuantity = 34, Category = pantry },
+            new Product { Name = "Brown Rice", Sku = "PAN-002", Price = 7.49m, StockQuantity = 50, Category = pantry },
+            new Product { Name = "Apples", Sku = "PRO-001", Price = 3.25m, StockQuantity = 80, Category = produce });
+
+        db.Orders.Add(new Order
+        {
+            CustomerName = "Walk-in Customer",
+            CreatedAtUtc = timeProvider.GetUtcNow().UtcDateTime,
+            TotalAmount = 22.48m,
+            Status = OrderStatus.Completed
+        });
+
+        db.SaveChanges();
+    }
+}

--- a/OnlineShop/Program.cs
+++ b/OnlineShop/Program.cs
@@ -1,41 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using OnlineShop.Data;
-using OnlineShop.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
 builder.Services.AddDbContext<ShopDbContext>(options =>
     options.UseSqlite(builder.Configuration.GetConnectionString("ShopDb") ?? "Data Source=shop.db"));
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<ShopDatabaseInitializer>();
 
 var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
 {
-    var db = scope.ServiceProvider.GetRequiredService<ShopDbContext>();
-    db.Database.EnsureCreated();
-
-    if (!db.Categories.Any())
-    {
-        var pantry = new Category { Name = "Pantry", Description = "Shelf-stable grocery items" };
-        var produce = new Category { Name = "Produce", Description = "Fresh fruits and vegetables" };
-
-        db.Categories.AddRange(pantry, produce);
-        db.Products.AddRange(
-            new Product { Name = "Olive Oil", Sku = "PAN-001", Price = 14.99m, StockQuantity = 34, Category = pantry },
-            new Product { Name = "Brown Rice", Sku = "PAN-002", Price = 7.49m, StockQuantity = 50, Category = pantry },
-            new Product { Name = "Apples", Sku = "PRO-001", Price = 3.25m, StockQuantity = 80, Category = produce });
-
-        db.Orders.Add(new Order
-        {
-            CustomerName = "Walk-in Customer",
-            CreatedAtUtc = DateTime.UtcNow,
-            TotalAmount = 22.48m,
-            Status = OrderStatus.Completed
-        });
-
-        db.SaveChanges();
-    }
+    scope.ServiceProvider.GetRequiredService<ShopDatabaseInitializer>().Initialize();
 }
 
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
### Motivation

- The application composition root (`Program.cs`) contained direct database creation, seed-data construction, and wall-clock access which made initialization hard to test and violated separation of concerns. 
- Consolidating initialization into a single component reduces coupling between startup orchestration and persistence concerns. 
- Introducing a `TimeProvider` boundary enables deterministic tests for time-dependent seed data.

### Description

- Added `OnlineShop/Data/ShopDatabaseInitializer.cs` which encapsulates `EnsureCreated()`, seed data insertion, idempotency check, and uses an injected `TimeProvider` for deterministic timestamps. 
- Updated `OnlineShop/Program.cs` to register `TimeProvider.System` and `ShopDatabaseInitializer` in DI and to invoke `ShopDatabaseInitializer.Initialize()` from the composition root instead of performing seeding inline. 
- Added a test project `OnlineShop.Tests` with `OnlineShop.Tests/Data/ShopDatabaseInitializerTests.cs` that uses an in-memory `SqliteConnection` and a `FixedTimeProvider` to verify seeding contents and idempotency. 
- Added `OnlineShop.Tests/Usings.cs` for global `xunit` usings and registered the test project in the solution file (`OnlineShop.sln`).

### Testing

- `dotnet test OnlineShop.sln` was attempted but could not run because the execution environment does not contain the .NET SDK, so C# build and xUnit execution are unverified. 
- Repository-level checks including `git diff --check` and automated assertions verifying the new files and solution registration succeeded. 
- A search confirmed that seed details were removed from the composition root (seed logic now lives in `OnlineShop/Data/ShopDatabaseInitializer.cs`).
- The added characterization tests exercise seed contents and idempotency and are ready to run in an environment with the .NET SDK (`dotnet test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d83eabec08324a68b73f9611450bd)